### PR TITLE
Update Black to version 22.12.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ LABEL "repository"="https://github.com/lgeiger/black-action"
 LABEL "homepage"="https://github.com/lgeiger/black-action"
 LABEL "maintainer"="Lukas Geiger <lukas.geiger94@gmail.com>"
 
-RUN pip install black==22.3.0
+RUN pip install black==22.12.0
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
Adding version 22.12.0 for use in https://github.com/tripactions/sagemaker-infra-pipeline (also added tag).