### PR TITLE
SECENG-1297 [skip ci] Create non-blocking workflow for static code analysis upon PR

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,9 @@
+name: Security analysis with Semgrep
+on:
+  workflow_dispatch: {}
+  pull_request: {}
+jobs:
+  call-workflow-passing-data:
+    uses: tripactions/ta-seceng-automation/.github/workflows/reusable.yml@main
+    secrets:
+      SEMGREP_REUSABLE_TOKEN: ${{ secrets.SEMGREP_ORG_APP_TOKEN }}


### PR DESCRIPTION
**What is this?**<p>The Security Team would like to run semgrep the static analysis tool Semgrep on every Merge Request (MR) across all Navan code repositories. Semgrep will be used to identify security vulnerabilities within code written by Navan developers.<p>**How will this impact my development workflows?**<p>Semgrep should have zero impact. It will run on every single merge request but it is not going to to block or fail your MR right now.  We know some of you have had concerns with Apiiro blocking your merge requests, and we worked hard to resolve them. In case of semgrep we are simply not enabling it in blocking mode.<p>**How it is different from Apiiro? Why do we need both?**<p>Semgrep analyzes data and code flow, and identifies issues within the source code. Apiiro currently only analyzes third party dependencies used in each code repository or secrets used for source code. These tools are complimentary and we need both to identify different classes of security issues.